### PR TITLE
Prevent increasing generated buffer

### DIFF
--- a/sky-color-clock.el
+++ b/sky-color-clock.el
@@ -135,7 +135,8 @@ otherwise result may be broken."
            (json-key-type 'symbol)
            (json-array-type 'list))
        (setq sky-color-clock--openweathermap-cache
-             (json-read-from-string (buffer-substring (point) (point-max))))))))
+             (json-read-from-string (buffer-substring (point) (point-max)))))
+     (url-mark-buffer-as-dead (current-buffer)))))
 
 (defun sky-color-clock--cloudiness ()
   "Get current cloudiness in percent from


### PR DESCRIPTION
こんにちは。sky-color-clockを使わせてもらって、mode lineに表示させています。

さて、`sky-color-clock-initialize-openweathermap-client`ではデフォルトで30分に1回`sky-color-clock--update-weather`することになりますが、これのたびに`url-retrieve`内部で`generate-new-buffer`で新たなバッファが作られています。
そのため、Emacsを長い間使っていると多くの \*http api.openweathermap.org:80\*-なバッファが作られることになります。(`buffer-list`関数で多くのバッファが作られたままなことがわかりました)

これによって特に支障はありませんが、多くのバッファが増え続け放置されているのがアレだと思ったので、url.elにある関数を参考にして`url-retrieve`のコールバックで`url-mark-buffer-as-dead`して、バッファが増え続けないようにしました。